### PR TITLE
Use pkg-config for libx11 and libxkbfile on Linux.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,12 +12,12 @@
             "deps/chromium/x/keysym_to_unicode.cc",
             "src/keyboard_x.cc"
           ],
-          "link_settings": {
-            "libraries": [
-              "-lX11",
-              "-lxkbfile"
-            ]
-          }
+          "include_dirs": [
+            "<!@(pkg-config x11 xkbfile --cflags | sed s/-I//g)"
+          ],
+          "libraries": [
+            "<!@(pkg-config x11 xkbfile --libs)"
+          ]
         }],
         ['OS=="freebsd"', {
           "sources": [


### PR DESCRIPTION
This is necessary to build native-keymap on NixOS, where the header files are not in the default include path.