### PR TITLE
Respect PKG_CONFIG to allow cross-build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,10 +13,10 @@
             "src/keyboard_x.cc"
           ],
           "include_dirs": [
-            "<!@(pkg-config x11 xkbfile --cflags | sed s/-I//g)"
+            "<!@(${PKG_CONFIG:-pkg-config} x11 xkbfile --cflags | sed s/-I//g)"
           ],
           "libraries": [
-            "<!@(pkg-config x11 xkbfile --libs)"
+            "<!@(${PKG_CONFIG:-pkg-config} x11 xkbfile --libs)"
           ]
         }],
         ['OS=="freebsd"', {


### PR DESCRIPTION
One use case of this change is setting `PKG_CONFIG=aarch64-linux-gnu-pkg-config` alongside `npm_config_arch=arm64`, etc', when building VS Code.