### PR TITLE
fix: add an napi handle scope for the callback

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
 - template: build-template.yml
   parameters:
     name: macOS
-    vmImage: 'macOS-10.13'
+    vmImage: macOS-latest
 
 - template: build-template.yml
   parameters:

--- a/src/keyboard_mac.mm
+++ b/src/keyboard_mac.mm
@@ -181,6 +181,8 @@ typedef struct {
 } NotificationCallbackData;
 
 void notificationCallback(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+  napi_handle_scope scope;
+
   NotificationCallbackData *data = (NotificationCallbackData *)observer;
   napi_env env = data->env;
   napi_async_context context = data->context;


### PR DESCRIPTION
Required for Electron 10 where the memory-leak-handle-scope was removed

cc @deepak1556 