### PR TITLE
Enable build on AIX

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -49,6 +49,18 @@
               '-framework Cocoa'
             ]
           }
+        }],
+        ['OS=="aix"', {
+          "sources": [
+            "deps/chromium/x/keysym_to_unicode.cc",
+            "src/keyboard_x.cc"
+          ],
+          "link_settings": {
+            "libraries": [
+              "-lX11",
+              "-lxkbfile"
+            ]
+          }
         }]
       ]
     }


### PR DESCRIPTION
Configure:

```
$ node-gyp configure
gyp info it worked if it ends with ok
gyp info using node-gyp@8.2.0
gyp info using node@14.18.0 | aix | ppc64
gyp info find Python using Python version 3.7.11 found at "/opt/freeware/bin/python3"
gyp info spawn /opt/freeware/bin/python3
gyp info spawn args [
gyp info spawn args   '/inst/node-v14.18.0-aix-ppc64/lib/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/inst/node-native-keymap/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/inst/node-v14.18.0-aix-ppc64/lib/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/root/.cache/node-gyp/14.18.0/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/14.18.0',
gyp info spawn args   '-Dnode_exp_file=/inst/node-v14.18.0-aix-ppc64/include/node/node.exp',
gyp info spawn args   '-Dnode_gyp_dir=/inst/node-v14.18.0-aix-ppc64/lib/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/14.18.0/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/inst/node-native-keymap',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
gyp info ok
```

Build:

```
$ node-gyp build
gyp info it worked if it ends with ok
gyp info using node-gyp@8.2.0
gyp info using node@14.18.0 | aix | ppc64
gyp info spawn gmake
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
gmake: Entering directory '/inst/node-native-keymap/build'
  CXX(target) Release/obj.target/keymapping/src/string_conversion.o
  CXX(target) Release/obj.target/keymapping/src/keymapping.o
  CXX(target) Release/obj.target/keymapping/deps/chromium/x/keysym_to_unicode.o
  CXX(target) Release/obj.target/keymapping/src/keyboard_x.o
  SOLINK_MODULE(target) Release/obj.target/keymapping.node
  COPY Release/keymapping.node
gmake: Leaving directory '/inst/node-native-keymap/build'
gyp info ok
```

Test:

```
$ npm test

> native-keymap@2.2.1 test /inst/node-native-keymap
> node test/test.js

getCurrentKeyboardLayout:  null
-------------
```