### PR TITLE
Fix build on FreeBSD 12

### DIFF
--- a/src/keymapping.h
+++ b/src/keymapping.h
@@ -12,6 +12,10 @@
 #include <vector>
 #include "../deps/chromium/keyboard_codes.h"
 
+#if defined(__unix__)
+#include <pthread.h>
+#endif
+
 #define CHECK_OK(x) if (x != napi_ok) return NULL
 
 namespace vscode_keyboard {


### PR DESCRIPTION
Include `pthread.h` for `pthread_t` to avoid the following build error on FreeBSD 12:

```
In file included from ../src/keyboard_x.cc:6:
../src/keymapping.h:40:3: error: unknown type name 'pthread_t'; did you mean 'pthread'?
  pthread_t tid;
  ^~~~~~~~~
  pthread
/usr/include/stdio.h:157:9: note: 'pthread' declared here
        struct pthread *_fl_owner;      /* current owner */
               ^
In file included from ../src/keyboard_x.cc:6:
../src/keymapping.h:40:13: error: field has incomplete type 'pthread'
  pthread_t tid;
            ^
/usr/include/stdio.h:157:9: note: forward declaration of 'pthread'
        struct pthread *_fl_owner;      /* current owner */
               ^
2 errors generated.
```