### PR TITLE
Improve cleanup path

### DIFF
--- a/src/keyboard_mac.mm
+++ b/src/keyboard_mac.mm
@@ -174,7 +174,7 @@ napi_value GetCurrentKeyboardLayoutImpl(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void notificationCallback(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+void NotificationCallback(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
   NotificationCallbackData *data = (NotificationCallbackData *)observer;
   InvokeNotificationCallback(data);
 }
@@ -183,9 +183,18 @@ void RegisterKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
   CFNotificationCenterRef center = CFNotificationCenterGetDistributedCenter();
 
   // add an observer
-  CFNotificationCenterAddObserver(center, data, notificationCallback,
+  CFNotificationCenterAddObserver(center, data, NotificationCallback,
     kTISNotifySelectedKeyboardInputSourceChanged, NULL,
     CFNotificationSuspensionBehaviorDeliverImmediately
+  );
+}
+
+void DisposeKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
+  CFNotificationCenterRef center = CFNotificationCenterGetDistributedCenter();
+
+  // remove the observer
+  CFNotificationCenterRemoveObserver(center, data,
+    kTISNotifySelectedKeyboardInputSourceChanged, NULL
   );
 }
 

--- a/src/keyboard_win.cc
+++ b/src/keyboard_win.cc
@@ -459,12 +459,14 @@ public:
 };
 
 void RegisterKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
-  data->listener = new TfInputListener(data);
-  data->listener->StartListening();
+  TfInputListener* listener = new TfInputListener(data);
+  listener->StartListening();
+  data->listener = listener;
 }
 
 void DisposeKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
-  data->listener->Release();
+  TfInputListener* listener = static_cast<TfInputListener*>(data->listener);
+  listener->Release();
 }
 
 napi_value IsISOKeyboardImpl(napi_env env, napi_callback_info info) {

--- a/src/keyboard_win.cc
+++ b/src/keyboard_win.cc
@@ -12,7 +12,6 @@
 #include <windows.h>
 #include <Msctf.h>
 #include <ime.h>
-#include <node.h>
 
 namespace {
 
@@ -420,7 +419,6 @@ public:
 
   virtual ~TfInputListener() {
     this->StopListening();
-    delete data_;
   }
 
   virtual HRESULT STDMETHODCALLTYPE OnActivated(
@@ -460,14 +458,13 @@ public:
   }
 };
 
-void ReleaseListener(void* data) {
-  reinterpret_cast<TfInputListener*>(data)->Release();
+void RegisterKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
+  data->listener = new TfInputListener(data);
+  data->listener->StartListening();
 }
 
-void RegisterKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
-  auto listener1 = new TfInputListener(data);
-  listener1->StartListening();
-  node::AddEnvironmentCleanupHook(v8::Isolate::GetCurrent(), ReleaseListener, listener1);
+void DisposeKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data) {
+  data->listener->Release();
 }
 
 napi_value IsISOKeyboardImpl(napi_env env, napi_callback_info info) {

--- a/src/keymapping.h
+++ b/src/keymapping.h
@@ -38,15 +38,19 @@ typedef struct {
 } KeycodeMapEntry;
 
 typedef struct {
+#if defined(_WIN32)
+  TfInputListener* listener;
+#endif
 #if defined(__unix__)
   pthread_t tid;
 #endif
-  napi_threadsafe_function tsfn;
+  volatile napi_threadsafe_function tsfn;
 } NotificationCallbackData;
 
 napi_value GetKeyMapImpl(napi_env env, napi_callback_info info);
 napi_value GetCurrentKeyboardLayoutImpl(napi_env env, napi_callback_info info);
 void RegisterKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data);
+void DisposeKeyboardLayoutChangeListenerImpl(NotificationCallbackData *data);
 napi_value IsISOKeyboardImpl(napi_env env, napi_callback_info info);
 
 void InvokeNotificationCallback(NotificationCallbackData *data);

--- a/src/keymapping.h
+++ b/src/keymapping.h
@@ -39,7 +39,7 @@ typedef struct {
 
 typedef struct {
 #if defined(_WIN32)
-  TfInputListener* listener;
+  void* listener;
 #endif
 #if defined(__unix__)
   pthread_t tid;


### PR DESCRIPTION
Address crashes observed via https://github.com/microsoft/vscode/issues/142316

* use `volatile` for `NotificationCallbackData.tsfn`
* add an env cleanup hook to dispose the keyboard layout change listener
* on macOS, remove the observer
* on windows, release the listener
* on linux, cancel the thread and join it

cc @deepak1556 