### PR TITLE
ci: fix support for vs 2022 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,14 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - run: npm ci
+      - run: |
+          # update node-gyp to latest for support in detecting VS 2022 toolchain
+          npm install -g node-gyp@latest
+          # Resolve to node-gyp.js
+          # Remove this once node-version >= 16.x,
+          # which ships with npm > 8.4.0 that has support for VS 2022 toolchain.
+          $env:npm_config_node_gyp=$(Join-Path $(Get-Command node-gyp.cmd).Path "..\node_modules\node-gyp\bin\node-gyp.js" -Resolve)
+          npm ci
       - run: npm test
 
   linux:


### PR DESCRIPTION
`windows-latest` now ships with VS 2022 toolchain as default.