### PR TITLE
Update binding.gyp to allow compiling against Electron 20+ headers

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,8 @@
         'VCCLCompilerTool': {
           'AdditionalOptions': [
             '/Qspectre',
-            '/guard:cf'
+            '/guard:cf',
+            '/std:c++17'
           ]
         },
         'VCLinkerTool': {
@@ -18,6 +19,9 @@
             '/guard:cf'
           ]
         }
+      },
+      "xcode_settings": {
+        'OTHER_CPLUSPLUSFLAGS': ['-std=c++17', '-stdlib=libc++'],
       },
       "conditions": [
         ['OS=="linux"', {


### PR DESCRIPTION
Currently, I cannot install `native-keymap` with `electron-builder` when targeting Electron@21.1. 

Electron builder compiles `native-keymap` against the chromium headers for the target version. In Electron 20+, they started using C++17 syntax, and `native-keymap` cannot compile against those headers. This PR changes `binding.gyp` so that `native-keymap` will compile against Electron 21's headers.

This addresses the issue described here: https://github.com/microsoft/node-native-keymap/issues/43#issuecomment-1295049743

Note: I'm not a cpp developer and I'm not 100% sure of the ramifications of changing the target. It compiles and works in electron quick-start though, so 🤞.