### PR TITLE
Fix casing of msctf.h header

### DIFF
--- a/src/keyboard_win.cc
+++ b/src/keyboard_win.cc
@@ -10,7 +10,7 @@
 
 #include "string_conversion.h"
 #include <windows.h>
-#include <Msctf.h>
+#include <msctf.h>
 #include <ime.h>
 
 namespace {


### PR DESCRIPTION
I ran into this cross compiling using a case-sensitive filesystem

The file I see in the SDK is lower cased:

`Windows Kits/10/Include/10.0.26100.0/um/msctf.h`