### PR TITLE
3.3.9

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
         "src/keymapping.cc"
       ],
       'cflags': [
-        '-O2', '-D_FORTIFY_SOURCE=2'
+        '-O2', '-D_FORTIFY_SOURCE=2', '-fstack-protector-strong'
       ],
       'msvs_configuration_attributes': {
         'SpectreMitigation': 'Spectre'

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
         "src/keymapping.cc"
       ],
       'cflags': [
-        '-O2', '-D_FORTIFY_SOURCE=2', '-fstack-protector-strong'
+        '-O2', '-fstack-protector-strong'
       ],
       'msvs_configuration_attributes': {
         'SpectreMitigation': 'Spectre'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "native-keymap",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "native-keymap",
-      "version": "3.3.8",
+      "version": "3.3.9",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-keymap",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "Get OS key mapping",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
This PR adds the stack-protector-strong flag. I confirmed that the binary grows by under 100 bytes. VS Code also does not call this library frequently, so I believe it does not require performance testing.